### PR TITLE
convertdate 2.4.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,30 @@
-{% set version = "2.3.2" %}
+{% set name = "convertdate" %}
+{% set version = "2.4.1" %}
 
 package:
-  name: convertdate
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/c/convertdate/convertdate-{{ version }}.tar.gz
-  sha256: 57df962a6047534f1452c390ad48e3dc5c83052ad83ad6dd78d60ae22f99214c
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ace904a9d0230742732471748160b99d6ae881c2d0dc9a2463c7a37340c56c91
 
 build:
-  skip: True    # [py<36]
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<37]
 
 requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=61.1.1
     - wheel
   run:
     - python
-    - pymeeus <=1,>=0.3.13
-    - pytz >=2014.10
+    - pymeeus >=0.3.13,<=1
 
+# Test setup missing in GH and PyPi
 test:
   imports:
     - convertdate
@@ -32,8 +32,6 @@ test:
   commands:
     - pip check
   requires:
-    # due to bug in conda build which causes python 3.10 to be used
-    - python <3.10
     - pip
 
 about:
@@ -43,7 +41,7 @@ about:
   license_file: LICENSE
   summary: "Converts between Gregorian dates and other calendar systems.Calendars included: Baha'i, French Republican, Hebrew, Indian Civil, Islamic, ISO, Julian, Mayan and Persian."
   dev_url: https://github.com/fitnr/convertdate
-  doc_url: https://convertdate.readthedocs.io/en/latest/
+  doc_url: https://convertdate.readthedocs.io
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
convertdate 2.4.1 

**Destination channel:** Defaults

### Links

- [PKG-12431]
- dev_url:        https://github.com/fitnr/convertdate/tree/v2.4.1
- conda_forge:    https://github.com/conda-forge/convertdate-feedstock
- pypi:           https://pypi.org/project/convertdate/2.4.1
- pypi inspector: https://inspector.pypi.io/project/convertdate/2.4.1

### Explanation of changes:

- new version number


[PKG-12431]: https://anaconda.atlassian.net/browse/PKG-12431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ